### PR TITLE
Add query all API endpoint

### DIFF
--- a/community-witness-api-server/src/main/java/org/communitywitness/api/Report.java
+++ b/community-witness-api-server/src/main/java/org/communitywitness/api/Report.java
@@ -181,7 +181,7 @@ public class Report {
         return id;
     }
 
-    // this is for jersey. do not use this method manually.
+    // this is for jersey
     public void setId(int id) {
         this.id = id;
     }

--- a/community-witness-api-server/src/main/java/org/communitywitness/api/ReportResource.java
+++ b/community-witness-api-server/src/main/java/org/communitywitness/api/ReportResource.java
@@ -18,20 +18,14 @@ import jakarta.ws.rs.core.Response;
 @Consumes(MediaType.APPLICATION_JSON)
 public class ReportResource {
 	/**
-	 * Returns a list of reports matching the restrictions in the query parameters, or just all the reports if no parameters are specified.
-	 * @param location - the location of the report(s)
-	 * @param time - the time range for when the report(s) were submitted
-	 * @return a list of reports matching the query
+	 * Returns all the reports in the database.
+	 * @return a list of reports
 	 */
 	@GET
-	public List<Report> queryReports(@QueryParam("location") String location, @QueryParam("time") String time) throws SQLException {
-		// TODO: modify this to accept a range of times and perhaps a radius relative to location (depending on front end needs)
+	public List<Report> queryReports() throws SQLException {
 		SQLConnection myConnection = new SQLConnection();
 		Connection conn = myConnection.databaseConnection();
-		String query = String.format("SELECT id, resolved, description, time, location, witnessID " +
-						"FROM report " +
-						"WHERE location='%s' " +
-						"AND time='%s';", location, time);
+		String query = "SELECT id, resolved, description, time, location, witnessID FROM report;";
 
 		Statement queryStatement = conn.createStatement();
 		ResultSet queryResults = queryStatement.executeQuery(query);
@@ -39,7 +33,12 @@ public class ReportResource {
 		ArrayList<Report> results = new ArrayList<>();
 
 		while (queryResults.next()) {
-			Report report = new Report(queryResults.getInt(1));
+			Report report = new Report(queryResults.getBoolean(2),
+					queryResults.getString(3),
+					queryResults.getTime(4),
+					queryResults.getString(5),
+					queryResults.getInt(6));
+			report.setId(queryResults.getInt(1));
 			results.add(report);
 		}
 

--- a/community-witness-api-server/src/test/java/org/communitywitness/api/ReportResourceTest.java
+++ b/community-witness-api-server/src/test/java/org/communitywitness/api/ReportResourceTest.java
@@ -17,7 +17,7 @@ class ReportResourceTest {
 
     @Test
     void queryReports() throws SQLException {
-        List<Report> myList = res.queryReports("test location", "2021-07-29 18:08:05.0");
+        List<Report> myList = res.queryReports();
         assertNotNull(myList);
     }
 


### PR DESCRIPTION
Changed queryReports to pull all reports out of database.
Also got rid of ridiculous functionality from before where queryReports hit the database once to pull all reports, and then iterated over a constructor that itself pulled individual reports out of the database.