### PR TITLE
Report class fixes

### DIFF
--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/NewReportRequest.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/NewReportRequest.java
@@ -1,0 +1,40 @@
+package org.communitywitness.api;
+
+import java.time.LocalDateTime;
+
+public class NewReportRequest {
+    private String description;
+    private LocalDateTime time;
+    private String location;
+    private int witnessId;
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public LocalDateTime getTime() { return time; }
+
+    public void setTime(LocalDateTime time) {
+        this.time = time;
+    }
+
+    public String getLocation() {
+        return location;
+    }
+
+    public void setLocation(String location) {
+        this.location = location;
+    }
+
+    public int getWitnessId() {
+        return witnessId;
+    }
+
+    public void setWitnessId(int witnessId) {
+        this.witnessId = witnessId;
+    }
+}

--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/Report.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/Report.java
@@ -1,8 +1,8 @@
 package org.communitywitness.api;
 
 import java.sql.*;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Date;
 
 import org.communitywitness.common.SpecialIds;
 
@@ -32,7 +32,7 @@ public class Report extends org.communitywitness.common.Report {
         if (queryResults.next()) {
             setResolved(queryResults.getBoolean(1));
             setDescription(queryResults.getString(2));
-            setTimestamp(new Date(queryResults.getTimestamp(3).getTime()));
+            setTimestamp(queryResults.getTimestamp(3).toLocalDateTime());
             setLocation(queryResults.getString(4));
             setWitnessId(queryResults.getInt(5));
         } else {
@@ -55,7 +55,7 @@ public class Report extends org.communitywitness.common.Report {
      * @param location    - location of occurrence
      * @param witnessId   - id of reporting witness
      */
-    public Report(boolean resolved, String description, Date time, String location, int witnessId) {
+    public Report(boolean resolved, String description, LocalDateTime time, String location, int witnessId) {
     	super(SpecialIds.UNSET_ID, resolved, description, time, location, witnessId, 
     			new ArrayList<Integer>(), new ArrayList<Integer>());
     }

--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/ReportResource.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/ReportResource.java
@@ -5,9 +5,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
-
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
@@ -35,7 +33,7 @@ public class ReportResource {
 		while (queryResults.next()) {
 			Report report = new Report(queryResults.getBoolean(2),
 					queryResults.getString(3),
-					queryResults.getTime(4),
+					queryResults.getTimestamp(4).toLocalDateTime(),
 					queryResults.getString(5),
 					queryResults.getInt(6));
 			report.setId(queryResults.getInt(1));
@@ -47,21 +45,17 @@ public class ReportResource {
 
 	/**
 	 * Creates a new report from data sent from a client.
-	 * @param description - a description of what took place
-	 * @param time - the time that the report took place
-	 * @param location - where the report took place
+	 * @param newReportRequestData - object containing data for new report
 	 * @return the id of the newly created report.
 	 */
 	@POST
-	public int createReport(@FormParam("description") String description,
-							@FormParam("time") Date time,
-							@FormParam("location") String location,
-							@FormParam("witnessId") int witnessId) throws SQLException {
-		Report newReport = new Report();
-		newReport.setDescription(description);
-		newReport.setTimestamp(time);
-		newReport.setLocation(location);
-		newReport.setWitnessId(witnessId);
+		public int createReport(NewReportRequest newReportRequestData) throws SQLException {
+		Report newReport = new Report(
+				false,
+				newReportRequestData.getDescription(),
+				newReportRequestData.getTime(),
+				newReportRequestData.getLocation(),
+				newReportRequestData.getWitnessId());
 		return newReport.writeToDb();
 	}
 	
@@ -92,8 +86,8 @@ public class ReportResource {
 	 * @return An OK status on success, otherwise a NOT_FOUND status when the report isn't found
 	 */
 	@PUT
-	@Path("/{reportId}")
-	public Response updateReportStatus(@PathParam("reportId") int reportId, @FormParam("status") boolean status) {
+	@Path("/{reportId}/{status}")
+	public Response updateReportStatus(@PathParam("reportId") int reportId, @PathParam("status") boolean status) {
 		Report toUpdate;
 		
 		try {

--- a/org-communitywitness-api/src/test/java/org/communitywitness/api/ReportResourceTest.java
+++ b/org-communitywitness-api/src/test/java/org/communitywitness/api/ReportResourceTest.java
@@ -1,14 +1,10 @@
 package org.communitywitness.api;
 
-import org.communitywitness.api.Report;
-import org.communitywitness.api.ReportResource;
 import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
-import java.util.Calendar;
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
-import java.util.ListIterator;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -23,8 +19,14 @@ class ReportResourceTest {
 
     @Test
     void createReportTest() throws SQLException {
-        Date time = new Date();
-        int myId = res.createReport("from unit test", time, "test location", 1);
+        LocalDateTime time = LocalDateTime.now();
+        NewReportRequest newReportRequestData= new NewReportRequest();
+        newReportRequestData.setDescription("description from unit test");
+        newReportRequestData.setTime(time);
+        newReportRequestData.setLocation("location from unit test");
+        newReportRequestData.setWitnessId(1);
+
+        int myId = res.createReport(newReportRequestData);
         assertNotEquals(-1, myId);
     }
 

--- a/org-communitywitness-api/src/test/java/org/communitywitness/api/ReportTest.java
+++ b/org-communitywitness-api/src/test/java/org/communitywitness/api/ReportTest.java
@@ -1,10 +1,9 @@
 package org.communitywitness.api;
 
-import org.communitywitness.api.Report;
 import org.junit.jupiter.api.Test;
 
 import java.sql.SQLException;
-import java.util.Date;
+import java.time.LocalDateTime;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -33,7 +32,7 @@ class ReportTest {
         int testId = 0;
         boolean testResolved = false;
         String testDescription = "foo";
-        Date testTime = new Date();
+        LocalDateTime testTime = LocalDateTime.now();
         String testLocation = "bar";
         int testWitnessId = 0;
 
@@ -43,7 +42,7 @@ class ReportTest {
         //store the data so we can write it back
         boolean realResolved = report3.getResolved();
         String realDescription = report3.getDescription();
-        Date realTime = report3.getTimestamp();
+        LocalDateTime realTime = report3.getTimestamp();
         String realLocation = report3.getLocation();
         int realWitnessId = report3.getWitnessId();
 
@@ -77,7 +76,7 @@ class ReportTest {
     void testWriteNewReportToDatabase() throws SQLException {
         boolean testResolved = false;
         String testDescription = "foo";
-        Date testTime = new Date();
+        LocalDateTime testTime = LocalDateTime.now();
         String testLocation = "bar";
         int testWitnessId = 0;
 
@@ -104,7 +103,7 @@ class ReportTest {
 
     @Test
     void setTime() {
-        Date testTime = new Date();
+        LocalDateTime testTime = LocalDateTime.now();
         report.setTimestamp(testTime);
         assertEquals(testTime, report.getTimestamp());
     }

--- a/org-communitywitness-common/src/main/java/org/communitywitness/common/Report.java
+++ b/org-communitywitness-common/src/main/java/org/communitywitness/common/Report.java
@@ -1,6 +1,6 @@
 package org.communitywitness.common;
 
-import java.util.Date;
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -12,7 +12,7 @@ public class Report {
     private int id = SpecialIds.UNSET_ID;
     private boolean resolved;
     private String description;
-    private Date timestamp;
+    private LocalDateTime timestamp;
     private String location;
     private int witnessId;
     private List<Integer> comments;
@@ -29,14 +29,14 @@ public class Report {
      * @param id see {@link #setId(int)}
      * @param resolved see {@link #setResolved(boolean)}
      * @param description see {@link #setDescription(String)}
-     * @param timestamp see {@link #setTimestamp(Date)}
+     * @param timestamp see {@link #setTimestamp(LocalDateTime)}
      * @param location see {@link #setLocation(String)}
      * @param witnessId see {@link #setWitnessId(int)}
      * @param comments see {@link #setComments(List)}
      * @param evidence see {@link #setEvidence(List)}
      */
-    public Report(int id, boolean resolved, String description, Date timestamp, 
-    		String location, int witnessId, List<Integer> comments, List<Integer> evidence) {
+    public Report(int id, boolean resolved, String description, LocalDateTime timestamp,
+                  String location, int witnessId, List<Integer> comments, List<Integer> evidence) {
     	setId(id);
     	setResolved(resolved);
     	setDescription(description);
@@ -99,7 +99,7 @@ public class Report {
      * Returns the date and time that the event this report concerns occurred.
      * @return this.timestamp
      */
-    public Date getTimestamp() {
+    public LocalDateTime getTimestamp() {
         return timestamp;
     }
 
@@ -107,7 +107,7 @@ public class Report {
      * Sets the timestamp of this report.
      * @param timestamp the date and time that the event this report concerns occurred
      */
-    public void setTimestamp(Date timestamp) {
+    public void setTimestamp(LocalDateTime timestamp) {
         this.timestamp = timestamp;
     }
 


### PR DESCRIPTION
All reports endpoints are now working. Moving from java.util.date to java.time.LocalDateTime fixed pretty much all the time-translation issues to/from postgres and over the api. @FormParam turns out to be the wrong annotation for JSON media type. Now that this is working, other classes can use similar structure.