### PR TITLE
fixed long report list not getting evidence/comments. 

### DIFF
--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/ReportResource.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/ReportResource.java
@@ -1,14 +1,15 @@
 package org.communitywitness.api;
 
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
-import jakarta.ws.rs.*;
-import jakarta.ws.rs.core.MediaType;
-import jakarta.ws.rs.core.Response;
 
 // TODO: implement user authentication for all of these calls
 @Path("/reports")
@@ -37,6 +38,8 @@ public class ReportResource {
 					queryResults.getString(5),
 					queryResults.getInt(6));
 			report.setId(queryResults.getInt(1));
+			report.loadComments();
+			report.loadEvidence();
 			results.add(report);
 		}
 


### PR DESCRIPTION
This is an expensive operation O(n), as it has to make two database queries for each report. This can and should be improved.