### PR TITLE
Perf improvement to GET /reports

### DIFF
--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/Report.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/Report.java
@@ -43,8 +43,8 @@ public class Report extends org.communitywitness.common.Report {
         queryStatement.close();
         
         // retrieve the ids of the comments and evidence relating to this report
-        loadComments();
-        loadEvidence();
+        loadComments(conn);
+        loadEvidence(conn);
     }
 
     /**
@@ -65,11 +65,9 @@ public class Report extends org.communitywitness.common.Report {
      * then saves that in this object.
      * @throws SQLException if no data is found
      */
-    public void loadComments() throws SQLException {
+    public void loadComments(Connection conn) throws SQLException {
         ArrayList<Integer> commentIds = new ArrayList<>();
 
-        SQLConnection myConnection = new SQLConnection();
-        Connection conn = myConnection.databaseConnection();
         String query = String.format("SELECT ID FROM ReportComments WHERE ReportID='%s';", getId());
         Statement queryStatement = conn.createStatement();
         ResultSet queryResults = queryStatement.executeQuery(query);
@@ -86,11 +84,9 @@ public class Report extends org.communitywitness.common.Report {
      * then saves that in this object.
      * @throws SQLException if no data is found
      */
-    public void loadEvidence() throws SQLException {
+    public void loadEvidence(Connection conn) throws SQLException {
         ArrayList<Integer> evidenceIds = new ArrayList<>();
 
-        SQLConnection myConnection = new SQLConnection();
-        Connection conn = myConnection.databaseConnection();
         String query = String.format("SELECT ID FROM Evidence WHERE ReportID='%s';", getId());
         Statement queryStatement = conn.createStatement();
         ResultSet queryResults = queryStatement.executeQuery(query);

--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/ReportResource.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/ReportResource.java
@@ -38,8 +38,9 @@ public class ReportResource {
 					queryResults.getString(5),
 					queryResults.getInt(6));
 			report.setId(queryResults.getInt(1));
-			report.loadComments();
-			report.loadEvidence();
+
+			report.loadComments(conn);
+			report.loadEvidence(conn);
 			results.add(report);
 		}
 


### PR DESCRIPTION
added parameter to loadComments and LoadEvidence methods that allows calling routine to share its SQL connection

Time to complete API call GET /reports improved from ~45 seconds to ~5.

By extension GET /reports/{reportId} should also improve, but in a much less dramatic way.