### PR TITLE
modified evidence to hold the actual image byte array instead of a link

### DIFF
--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/Evidence.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/Evidence.java
@@ -17,7 +17,7 @@ public class Evidence extends org.communitywitness.common.Evidence {
 	 */
 	public Evidence(int id) throws SQLException {
 		Connection conn = new SQLConnection().databaseConnection();
-		String query = "SELECT Title, Type, Timestamp, Link, reportID " +
+		String query = "SELECT Title, Type, Timestamp, Data, reportID " +
 				"FROM Evidence " +
 				"WHERE ID=?";
 		PreparedStatement queryStatement = conn.prepareStatement(query);
@@ -29,7 +29,7 @@ public class Evidence extends org.communitywitness.common.Evidence {
 			setTitle(queryResults.getString(1));
 			setType(queryResults.getString(2));
 			setTimestamp(queryResults.getTimestamp(3).toLocalDateTime());
-			setLink(queryResults.getString(4));
+			setData(queryResults.getBytes(4));
 			setReportId(queryResults.getInt(5));
 		} else {
 			throw new RuntimeException("Evidence with the supplied ID does not exist in database");
@@ -48,7 +48,7 @@ public class Evidence extends org.communitywitness.common.Evidence {
 		setTitle(newEvidenceRequest.getTitle());
 		setType(newEvidenceRequest.getType());
 		setTimestamp(newEvidenceRequest.getTimestamp());
-		setLink(newEvidenceRequest.getLink());
+		setData(newEvidenceRequest.getData());
 		setReportId(newEvidenceRequest.getReportId());
 	}
 
@@ -66,14 +66,14 @@ public class Evidence extends org.communitywitness.common.Evidence {
 		// if the evidence is brand new (has not been written to the db yet), it will have an id of -1
 		// once the evidence gets written, it is given an id by the db which will be pulled back into the object
 		if (getId() == SpecialIds.UNSET_ID) {
-			String query = "INSERT INTO evidence (title, type, timestamp, link, reportid) " +
+			String query = "INSERT INTO evidence (title, type, timestamp, data, reportid) " +
 							"VALUES (?,?,?,?,?);";
 
 			PreparedStatement queryStatement = conn.prepareStatement(query, Statement.RETURN_GENERATED_KEYS);
 			queryStatement.setString(1, getTitle());
 			queryStatement.setString(2, getType());
 			queryStatement.setTimestamp(3, java.sql.Timestamp.valueOf(getTimestamp()));
-			queryStatement.setString(4, getLink());
+			queryStatement.setBytes(4, getData());
 			queryStatement.setInt(5, getReportId());
 
 			int rows = queryStatement.executeUpdate();
@@ -97,7 +97,7 @@ public class Evidence extends org.communitywitness.common.Evidence {
 							"title=?, " +
 							"type=?, " +
 							"timestamp=?, " +
-							"link=?, " +
+							"data=?, " +
 							"reportid=? " +
 							"WHERE id=?";
 
@@ -105,7 +105,7 @@ public class Evidence extends org.communitywitness.common.Evidence {
 			queryStatement.setString(1, getTitle());
 			queryStatement.setString(2, getType());
 			queryStatement.setTimestamp(3, java.sql.Timestamp.valueOf(getTimestamp()));
-			queryStatement.setString(4, getLink());
+			queryStatement.setBytes(4, getData());
 			queryStatement.setInt(5, getReportId());
 			queryStatement.setInt(6, getId());
 

--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/EvidenceResource.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/EvidenceResource.java
@@ -4,13 +4,8 @@ import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
-import java.net.URLConnection;
 import java.sql.SQLException;
-import java.util.Base64;
 
 @Path("/evidence")
 @Produces(MediaType.APPLICATION_JSON)
@@ -25,14 +20,6 @@ public class EvidenceResource {
 	 */
 	@POST
 	public int createEvidence(NewEvidenceRequest newEvidenceRequestData) throws WebApplicationException, SQLException, IOException {
-		String dirname;
-		String filename;
-		File directory;
-		FileOutputStream out = null;
-
-		// sets write directory to windows project dir if api is running locally
-		boolean localAPI = System.getProperty("os.name").equals("Windows 10");
-
 		// check if the report exists
 		try {
 			new Report(newEvidenceRequestData.getReportId());
@@ -40,36 +27,6 @@ public class EvidenceResource {
 			throw new WebApplicationException(Response.Status.NOT_FOUND);
 		}
 
-		if (localAPI)
-		{
-			dirname = System.getProperty("user.dir") + "\\"
-					+ newEvidenceRequestData.getReportId() + "\\";
-		} else {
-			dirname = "/home/kaz4_pdx_edu/communityWitnessImages/"
-					+ newEvidenceRequestData.getReportId() + "/";
-		}
-
-		directory = new File (dirname);
-		if (!directory.exists()) {
-			directory.mkdirs();
-		}
-
-		try {
-			byte[] byteArray = Base64.getMimeDecoder().decode(newEvidenceRequestData.getData());
-			filename = dirname
-					+ newEvidenceRequestData.getTimestamp().toString().replaceAll("[^a-zA-Z0-9]", "_")
-					+ URLConnection.guessContentTypeFromStream(new ByteArrayInputStream(byteArray)).replaceAll("image/", ".");			out = new FileOutputStream(filename);
-			out.write(byteArray);
-
-		} catch (IOException ioException) {
-			ioException.printStackTrace();
-		} finally {
-			if (out != null) {
-				out.close();
-			}
-		}
-
-		newEvidenceRequestData.setLink(dirname);
 		Evidence newEvidence = new Evidence(newEvidenceRequestData);
 		return newEvidence.writeToDb();
 	}

--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/NewEvidenceRequest.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/NewEvidenceRequest.java
@@ -6,9 +6,8 @@ public class NewEvidenceRequest {
     private String title;
     private String type;
     private LocalDateTime timestamp;
-    private String link;
     private int reportId;
-    private String data;
+    private byte[] data;
 
     public String getTitle() {
         return title;
@@ -34,14 +33,6 @@ public class NewEvidenceRequest {
         this.timestamp = timestamp;
     }
 
-    public String getLink() {
-        return link;
-    }
-
-    public void setLink(String link) {
-        this.link = link;
-    }
-
     public int getReportId() {
         return reportId;
     }
@@ -50,11 +41,11 @@ public class NewEvidenceRequest {
         this.reportId = reportId;
     }
 
-    public String getData() {
+    public byte[] getData() {
         return data;
     }
 
-    public void setData(String data) {
+    public void setData(byte[] data) {
         this.data = data;
     }
 }

--- a/org-communitywitness-api/src/test/java/org/communitywitness/api/EvidenceResourceTest.java
+++ b/org-communitywitness-api/src/test/java/org/communitywitness/api/EvidenceResourceTest.java
@@ -8,7 +8,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.sql.SQLException;
 import java.time.LocalDateTime;
-import java.util.Base64;
 
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -20,7 +19,7 @@ class EvidenceResourceTest {
     void createEvidence() throws IOException, SQLException {
         String location = "test.png";
         Path path = Paths.get(location);
-        String data = Base64.getEncoder().encodeToString(Files.readAllBytes(path));
+        byte[] data = Files.readAllBytes(path);
 
         NewEvidenceRequest req = new NewEvidenceRequest();
         req.setTitle("From unit test");
@@ -35,7 +34,7 @@ class EvidenceResourceTest {
 
     @Test
     void getEvidence() {
-        int id = 0;
+        int id = 283;
         Evidence evidence = res.getEvidence(id);
         assertNotNull(evidence);
     }

--- a/org-communitywitness-api/src/test/java/org/communitywitness/api/EvidenceTest.java
+++ b/org-communitywitness-api/src/test/java/org/communitywitness/api/EvidenceTest.java
@@ -14,13 +14,12 @@ class EvidenceTest {
 
     @Test
     void testChangeAndWriteToDatabase() throws SQLException {
-        int testId = 0;
+        int testId = 283;
         String testTitle = "description from testChangeAndWriteToDatabase unit test";
         String testType = "type from testChangeAndWriteToDatabase unit test";
         // Needed to truncate this to microseconds to get the assertion to work
         // Database chops off the last three digits on write
         LocalDateTime testTime = LocalDateTime.now().truncatedTo(ChronoUnit.MICROS);
-        String testLink = "link from testChangeAndWriteToDatabase unit test";
         int testReportId = 0;
 
         Evidence evidence = new Evidence(testId);
@@ -29,14 +28,12 @@ class EvidenceTest {
         String realTitle = evidence.getTitle();
         String realType = evidence.getType();
         LocalDateTime realTime = evidence.getTimestamp();
-        String realLink = evidence.getLink();
         int realReportId = evidence.getReportId();
 
         //make changes and write to db
         evidence.setTitle(testTitle);
         evidence.setType(testType);
         evidence.setTimestamp(testTime);
-        evidence.setLink(testLink);
         evidence.setReportId(testReportId);
         evidence.writeToDb();
 
@@ -45,14 +42,12 @@ class EvidenceTest {
         assertEquals(testTitle, evidence.getTitle());
         assertEquals(testType, evidence.getType());
         assertEquals(testTime, evidence.getTimestamp());
-        assertEquals(testLink, evidence.getLink());
         assertEquals(testReportId, evidence.getReportId());
 
         //roll back the changes
         evidence.setTitle(realTitle);
         evidence.setType(realType);
         evidence.setTimestamp(realTime);
-        evidence.setLink(realLink);
         evidence.setReportId(realReportId);
         evidence.writeToDb();
     }
@@ -61,7 +56,6 @@ class EvidenceTest {
     void testWriteNewEvidenceToDatabase() throws SQLException {
         String testTitle = "description from testWriteNewEvidenceToDatabase unit test";
         String testType = "type from testWriteNewEvidenceToDatabase unit test";
-        String testLink = "link from testWriteNewEvidenceToDatabase unit test";
         LocalDateTime testTime = LocalDateTime.now();
         int testReportId = 0;
 
@@ -69,7 +63,6 @@ class EvidenceTest {
         evidenceRequest.setTitle(testTitle);
         evidenceRequest.setType(testType);
         evidenceRequest.setTimestamp(testTime);
-        evidenceRequest.setLink(testLink);
         evidenceRequest.setReportId(testReportId);
         Evidence evidence = new Evidence(evidenceRequest);
         int id = evidence.writeToDb();
@@ -98,13 +91,6 @@ class EvidenceTest {
         LocalDateTime testTime = LocalDateTime.now();
         evidence.setTimestamp(testTime);
         assertEquals(testTime, evidence.getTimestamp());
-    }
-
-    @Test
-    void setLink() {
-        String testLink = "Foo";
-        evidence.setLink(testLink);
-        assertEquals(testLink, evidence.getLink());
     }
 
     @Test

--- a/org-communitywitness-common/src/main/java/org/communitywitness/common/Evidence.java
+++ b/org-communitywitness-common/src/main/java/org/communitywitness/common/Evidence.java
@@ -12,7 +12,7 @@ public class Evidence {
 	private String title;
 	private String type;
 	private LocalDateTime timestamp;
-	private String link;
+	private byte[] data;
 	private int reportId;
 
 	/**
@@ -28,15 +28,15 @@ public class Evidence {
 	 * @param title see {@link #setTitle(String)}
 	 * @param type see {@link #setType(String)}
 	 * @param timestamp see {@link #setTimestamp(LocalDateTime)}
-	 * @param link see {@link #setLink(String)}
+	 * @param data see {@link #setData(byte[])}
 	 * @param reportId see {@link #setReportId(int)}
 	 */
-	public Evidence(int id, String title, String type, LocalDateTime timestamp, String link, int reportId) {
+	public Evidence(int id, String title, String type, LocalDateTime timestamp, byte[] data, int reportId) {
 		setId(id);
 		setTitle(title);
 		setType(type);
 		setTimestamp(timestamp);
-		setLink(link);
+		setData(data);
 		setReportId(reportId);
 	}
 
@@ -108,16 +108,16 @@ public class Evidence {
 	 * Returns the location of the file containing this evidence.
 	 * @return this.link
 	 */
-	public String getLink() {
-		return link;
+	public byte[] getData() {
+		return data;
 	}
 
 	/**
 	 * Sets the link for this evidence.
-	 * @param link the location of the file containing this evidence
+	 * @param data the location of the file containing this evidence
 	 */
-	public void setLink(String link) {
-		this.link = link;
+	public void setData(byte[] data) {
+		this.data = data;
 	}
 
 	/**


### PR DESCRIPTION
added data column to evidence table
removed link column
GET /evidence/{evidenceId} now retrieves the byte array of the image