### PR TITLE
Improved database access performance

### DIFF
--- a/org-communitywitness-api/build.gradle
+++ b/org-communitywitness-api/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation 'commons-validator:commons-validator:1.7'
     implementation 'com.kosprov.jargon2:jargon2-api:1.1.1'
     runtimeOnly 'com.kosprov.jargon2:jargon2-native-ri-backend:1.1.1'
+    implementation 'com.zaxxer:HikariCP:5.0.0'
     implementation 'jakarta.ws.rs:jakarta.ws.rs-api:3.0.0'
     implementation 'org.glassfish.grizzly:grizzly-http-server:3.0.0'
     implementation 'org.glassfish.jersey.core:jersey-server:3.0.2'

--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/APIResourceConfig.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/APIResourceConfig.java
@@ -5,6 +5,10 @@ import org.glassfish.jersey.process.internal.RequestScoped;
 import org.glassfish.jersey.server.ResourceConfig;
 
 public class APIResourceConfig extends ResourceConfig {
+	
+	/**
+	 * Constructs a ResourceConfig for the API
+	 */
 	public APIResourceConfig() {
 		// Scan for resources in this package
 		packages("org.communitywitness.api");

--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/AuthenticatedUser.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/AuthenticatedUser.java
@@ -32,12 +32,12 @@ public class AuthenticatedUser implements SecurityContext {
 			
 		// Check the api key against the database
 		try {
-			SQLConnection myConnection = new SQLConnection();
-			Connection dbConnection = myConnection.databaseConnection();
+			Connection dbConnection = SQLConnection.databaseConnection();
 			String query = "SELECT WitnessId, InvestigatorId FROM ApiKeys WHERE ApiKey=?";
 			PreparedStatement queryStatement = dbConnection.prepareStatement(query);
 			queryStatement.setString(1, apiKey);
 			ResultSet queryResults = queryStatement.executeQuery();
+			
 			
 			int witnessId;
 			int investigatorId;
@@ -45,8 +45,11 @@ public class AuthenticatedUser implements SecurityContext {
 				witnessId = queryResults.getInt(1);
 				investigatorId = queryResults.getInt(2);
 			} else {
+				SQLConnection.closeDbOperation(dbConnection, queryStatement, queryResults);
 				throw new SQLException();
 			}
+			
+			SQLConnection.closeDbOperation(dbConnection, queryStatement, queryResults);
 			
 			// Determine the users role
 			if (witnessId == SpecialIds.USER_NOT_IN_ROLE && !SpecialIds.isSpecialId(investigatorId)) {
@@ -76,8 +79,7 @@ public class AuthenticatedUser implements SecurityContext {
 
 		// Check the login details against the database
 		try {
-			SQLConnection myConnection = new SQLConnection();
-			Connection dbConnection = myConnection.databaseConnection();
+			Connection dbConnection = SQLConnection.databaseConnection();
 			String query = "SELECT PasswordHash, InvestigatorId" +
 					"FROM Accounts WHERE Username=?";
 			PreparedStatement queryStatement = dbConnection.prepareStatement(query);
@@ -90,8 +92,10 @@ public class AuthenticatedUser implements SecurityContext {
 				passwordHash = queryResults.getString(1);
 				setId(queryResults.getInt(2));
 			} else {
+				SQLConnection.closeDbOperation(dbConnection, queryStatement, queryResults);
 				throw new SQLException();
 			}
+			SQLConnection.closeDbOperation(dbConnection, queryStatement, queryResults);
 			
 			// Check that the given password matches the db entry
 			if (!AccountManagement.checkPassword(passwordHash, password))

--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/AuthorizationFilter.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/AuthorizationFilter.java
@@ -22,6 +22,9 @@ public class AuthorizationFilter implements ContainerRequestFilter {
 	@Context
 	private ResourceInfo targetResource;
 	
+	/**
+	 * A filter that handles checking a user authentication data against the roles allowed by a method.
+	 */
 	@Override
 	public void filter(ContainerRequestContext requestContext) throws IOException {
 		Method targetMethod = targetResource.getResourceMethod();

--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/BadLoginException.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/BadLoginException.java
@@ -4,6 +4,10 @@ public class BadLoginException extends Exception {
 	// Random serial id to make eclipse happy
 	private static final long serialVersionUID = 4159178255142195703L;
 
+	/**
+	 * Constructs an exception regarding bad login data.
+	 * @param reason the specific reason that the login failed
+	 */
 	public BadLoginException(String reason) {
 		super(reason);
 	}

--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/ChatMessage.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/ChatMessage.java
@@ -24,7 +24,7 @@ public class ChatMessage extends org.communitywitness.common.ChatMessage {
     }
 
     public int writeToDb() throws SQLException {
-        Connection conn = new SQLConnection().databaseConnection();
+        Connection conn = SQLConnection.databaseConnection();
 
         String query = "INSERT INTO chat (reportid, investigatorid, message, time) " +
                 "VALUES (?,?,?,?)";
@@ -37,6 +37,7 @@ public class ChatMessage extends org.communitywitness.common.ChatMessage {
 
         int rows = queryStatement.executeUpdate();
         if (rows == 0) {
+        	SQLConnection.closeDbOperation(conn, queryStatement, null);
             throw new SQLException("Message insertion failed");
         }
 

--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/ChatResource.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/ChatResource.java
@@ -34,7 +34,7 @@ public class ChatResource {
 
 		// try to retrieve the messages
 		try {
-			Connection conn = new SQLConnection().databaseConnection();
+			Connection conn = SQLConnection.databaseConnection();
 			String query = "SELECT id, reportid, investigatorid, message, time FROM chat WHERE investigatorid=?";
 			PreparedStatement preparedStatement = conn.prepareStatement(query);
 			preparedStatement.setInt(1, id);
@@ -55,8 +55,7 @@ public class ChatResource {
 			}
 
 			// close out sql stuff
-			queryResults.close();
-			conn.close();
+			SQLConnection.closeDbOperation(conn, preparedStatement, queryResults);
 
 			return messages;
 		} catch (SQLException exception) {
@@ -82,7 +81,7 @@ public class ChatResource {
 		try {
 			List<Integer> reportIdString = new Witness(id).getReports();
 
-			Connection conn = new SQLConnection().databaseConnection();
+			Connection conn = SQLConnection.databaseConnection();
 			String query = String.format("SELECT id, reportid, investigatorid, message, time FROM chat WHERE reportid IN (%s)",
 					reportIdString.stream()
 					.map(v -> "?")
@@ -109,8 +108,7 @@ public class ChatResource {
 			}
 
 			// close out sql stuff
-			queryResults.close();
-			conn.close();
+			SQLConnection.closeDbOperation(conn, preparedStatement, queryResults);
 
 			return messages;
 		} catch (SQLException exception) {

--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/ChatResource.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/ChatResource.java
@@ -4,6 +4,7 @@ import jakarta.annotation.security.RolesAllowed;
 import jakarta.ws.rs.*;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 
 import java.sql.Connection;
 import java.sql.PreparedStatement;
@@ -17,112 +18,146 @@ import java.util.stream.Collectors;
 @Produces(MediaType.APPLICATION_JSON)
 @Consumes(MediaType.APPLICATION_JSON)
 public class ChatResource {
-    /**
-     * Returns all chat messages for the given investigator
-     * @returns a list of messages
-     */
+	/**
+	 * Returns all chat messages for the given investigator
+	 * @param id the ID number of the investigator whose messages to retrieve
+	 * @param user the authentication data of the requesting user
+	 * @return a list of messages involving the given investigator
+	 * @throws WebApplicationException on authorization error or database reading error
+	 */
 	@RolesAllowed({UserRoles.INVESTIGATOR})
-    @GET
-    @Path("/investigator/{investigatorId}")
-    public List<ChatMessage> investigatorMessages(@PathParam("investigatorId") int id, @Context AuthenticatedUser user) throws WebApplicationException, SQLException {
+	@GET
+	@Path("/investigator/{investigatorId}")
+	public List<ChatMessage> investigatorMessages(@PathParam("investigatorId") int id, @Context AuthenticatedUser user) throws WebApplicationException {
 		if (user.getId() != id)
 			throw new WebApplicationException(AuthorizationFilter.unauthorizedAccessResponse("Investigators may only view their own messages."));
-		
-        Connection conn = new SQLConnection().databaseConnection();
-        String query = "SELECT id, reportid, investigatorid, message, time FROM chat WHERE investigatorid=?";
-        PreparedStatement preparedStatement = conn.prepareStatement(query);
-        preparedStatement.setInt(1, id);
-        ResultSet queryResults = preparedStatement.executeQuery();
 
-        ArrayList<ChatMessage> messages = new ArrayList<>();
+		// try to retrieve the messages
+		try {
+			Connection conn = new SQLConnection().databaseConnection();
+			String query = "SELECT id, reportid, investigatorid, message, time FROM chat WHERE investigatorid=?";
+			PreparedStatement preparedStatement = conn.prepareStatement(query);
+			preparedStatement.setInt(1, id);
+			ResultSet queryResults = preparedStatement.executeQuery();
 
-        while (queryResults.next()) {
-            ChatMessage message = new ChatMessage(
-                    queryResults.getInt(2),
-                    queryResults.getInt(3),
-                    queryResults.getString(4),
-                    queryResults.getTimestamp(5).toLocalDateTime());
+			ArrayList<ChatMessage> messages = new ArrayList<>();
 
-            message.setId(queryResults.getInt(1));
+			while (queryResults.next()) {
+				ChatMessage message = new ChatMessage(
+						queryResults.getInt(2),
+						queryResults.getInt(3),
+						queryResults.getString(4),
+						queryResults.getTimestamp(5).toLocalDateTime());
 
-            messages.add(message);
-        }
+				message.setId(queryResults.getInt(1));
 
-        // close out sql stuff
-        queryResults.close();
-        conn.close();
+				messages.add(message);
+			}
 
-        return messages;
-    }
+			// close out sql stuff
+			queryResults.close();
+			conn.close();
 
-    /**
-     * Returns all chat messages for the given witness
-     * @returns a list of messages
-     */
+			return messages;
+		} catch (SQLException exception) {
+			throw new WebApplicationException(Response.Status.NOT_FOUND);
+		}
+	}
+
+	/**
+	 * Returns all chat messages for the given witness
+	 * @param id the ID number of the witness whose messages to retrieve
+	 * @param user the authentication data of the requesting user
+	 * @return a list of messages involving the given witness
+	 * @throws WebApplicationException on authorization errors or database read failures
+	 */
 	@RolesAllowed({UserRoles.WITNESS})
-    @GET
-    @Path("/witness/{witnessId}")
-    public List<ChatMessage> witnessMessages(@PathParam("witnessId") int id, @Context AuthenticatedUser user) throws SQLException {
+	@GET
+	@Path("/witness/{witnessId}")
+	public List<ChatMessage> witnessMessages(@PathParam("witnessId") int id, @Context AuthenticatedUser user) throws WebApplicationException {
 		if (user.getId() != id)
 			throw new WebApplicationException(AuthorizationFilter.unauthorizedAccessResponse("Witnesses may only view their own messages."));
-		
-        List<Integer> reportIdString = new Witness(id).getReports();
 
-        Connection conn = new SQLConnection().databaseConnection();
-        String query = String.format("SELECT id, reportid, investigatorid, message, time FROM chat WHERE reportid IN (%s)",
-                reportIdString.stream()
-                .map(v -> "?")
-                .collect(Collectors.joining(", ")));
-        PreparedStatement preparedStatement = conn.prepareStatement(query);
+		// try to retrieve the messages
+		try {
+			List<Integer> reportIdString = new Witness(id).getReports();
 
-//        preparedStatement.setString(1, reportIdString);
-        for (int i=1; i<= reportIdString.size(); i++) {
-            preparedStatement.setInt(i, reportIdString.get(i-1));
-        }
-        ResultSet queryResults = preparedStatement.executeQuery();
+			Connection conn = new SQLConnection().databaseConnection();
+			String query = String.format("SELECT id, reportid, investigatorid, message, time FROM chat WHERE reportid IN (%s)",
+					reportIdString.stream()
+					.map(v -> "?")
+					.collect(Collectors.joining(", ")));
+			PreparedStatement preparedStatement = conn.prepareStatement(query);
 
-        ArrayList<ChatMessage> messages = new ArrayList<>();
+			for (int i=1; i<= reportIdString.size(); i++) {
+				preparedStatement.setInt(i, reportIdString.get(i-1));
+			}
+			ResultSet queryResults = preparedStatement.executeQuery();
 
-        while (queryResults.next()) {
-            ChatMessage message = new ChatMessage(
-                    queryResults.getInt(2),
-                    queryResults.getInt(3),
-                    queryResults.getString(4),
-                    queryResults.getTimestamp(5).toLocalDateTime());
+			ArrayList<ChatMessage> messages = new ArrayList<>();
 
-            message.setId(queryResults.getInt(1));
+			while (queryResults.next()) {
+				ChatMessage message = new ChatMessage(
+						queryResults.getInt(2),
+						queryResults.getInt(3),
+						queryResults.getString(4),
+						queryResults.getTimestamp(5).toLocalDateTime());
 
-            messages.add(message);
-        }
+				message.setId(queryResults.getInt(1));
 
-        // close out sql stuff
-        queryResults.close();
-        conn.close();
+				messages.add(message);
+			}
 
-        return messages;
-    }
+			// close out sql stuff
+			queryResults.close();
+			conn.close();
 
+			return messages;
+		} catch (SQLException exception) {
+			throw new WebApplicationException(Response.Status.NOT_FOUND);
+		}
+	}
+
+	/**
+	 * Writes a chat message to the database.
+	 * @param reportId the ID of the report this message is addressing
+	 * @param chatMessageRequest the data about and contents of the message
+	 * @param user the authentication data of the requesting user
+	 * @return the id of the newly created message
+	 * @throws WebApplicationException on authorization failure, 
+	 * if the message doesn't address a valid report, or database writing fails.
+	 */
 	@RolesAllowed({UserRoles.INVESTIGATOR, UserRoles.WITNESS})
-    @PUT
-    @Path("/{reportId}")
-    public int addMessage(@PathParam("reportId") int reportId, ChatMessageRequest chatMessageRequest, @Context AuthenticatedUser user) throws WebApplicationException, SQLException {
+	@PUT
+	@Path("/{reportId}")
+	public int addMessage(@PathParam("reportId") int reportId, ChatMessageRequest chatMessageRequest, @Context AuthenticatedUser user) throws WebApplicationException {
 		// Verify that the user is allowed to send this message
 		if (user.isUserInRole(UserRoles.INVESTIGATOR) && user.getId() != chatMessageRequest.getInvestigatorId())
 			throw new WebApplicationException(AuthorizationFilter.unauthorizedAccessResponse("Investigators may only send messages as themselves."));
-		
-		if (user.isUserInRole(UserRoles.WITNESS)) {
-			Report relevantReport = new Report(reportId);
-			if (user.getId() != relevantReport.getWitnessId())
-				throw new WebApplicationException(AuthorizationFilter.unauthorizedAccessResponse("Witnesses may only send messages regarding their reports."));
+
+		try {
+			if (user.isUserInRole(UserRoles.WITNESS)) {
+				Report relevantReport = new Report(reportId);
+				if (user.getId() != relevantReport.getWitnessId())
+					throw new WebApplicationException(AuthorizationFilter.unauthorizedAccessResponse("Witnesses may only send messages regarding their reports."));
+			}
+		} catch (SQLException exception) {
+			throw new WebApplicationException("Messages must address existing reports.");
 		}
-		
-        ChatMessage message = new ChatMessage(
-                reportId,
-                chatMessageRequest.getInvestigatorId(),
-                chatMessageRequest.getMessage(),
-                chatMessageRequest.getTime());
-        return message.writeToDb();
-    }
+
+
+		// try to write the message
+		try {
+			ChatMessage message = new ChatMessage(
+					reportId,
+					chatMessageRequest.getInvestigatorId(),
+					chatMessageRequest.getMessage(),
+					chatMessageRequest.getTime());
+			return message.writeToDb();
+		} catch (SQLException exception) {
+			throw new WebApplicationException("Failed to write message to database.");
+		}
+	}
 }
 
 

--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/CorsFilter.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/CorsFilter.java
@@ -19,6 +19,9 @@ public class CorsFilter implements ContainerRequestFilter, ContainerResponseFilt
 	// The methods that Cross-Origin clients are allowed to send
 	private static final String ALLOWED_METHODS = "GET, POST, PUT, DELETE, OPTIONS, HEAD";
 	
+	/**
+	 * A filter that checks for CORS requests and handles them accordingly
+	 */
     @Override
     public void filter(ContainerRequestContext request) throws IOException {
 
@@ -41,6 +44,9 @@ public class CorsFilter implements ContainerRequestFilter, ContainerResponseFilt
                 && request.getMethod().equalsIgnoreCase("OPTIONS");
     }
 
+    /**
+     * A filter that attaches CORS data to responses as needed.
+     */
     @Override
     public void filter(ContainerRequestContext request, ContainerResponseContext response)
             throws IOException {

--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/Evidence.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/Evidence.java
@@ -16,7 +16,7 @@ public class Evidence extends org.communitywitness.common.Evidence {
 	 * @param id - the id of the evidence to lookup in the database.
 	 */
 	public Evidence(int id) throws SQLException {
-		Connection conn = new SQLConnection().databaseConnection();
+		Connection conn = SQLConnection.databaseConnection();
 		String query = "SELECT Title, Type, Timestamp, Data, reportID " +
 				"FROM Evidence " +
 				"WHERE ID=?";
@@ -32,12 +32,12 @@ public class Evidence extends org.communitywitness.common.Evidence {
 			setData(queryResults.getBytes(4));
 			setReportId(queryResults.getInt(5));
 		} else {
+			SQLConnection.closeDbOperation(conn, queryStatement, queryResults);
 			throw new RuntimeException("Evidence with the supplied ID does not exist in database");
 		}
 
 		// close out sql stuff
-		queryStatement.close();
-		conn.close();
+		SQLConnection.closeDbOperation(conn, queryStatement, queryResults);
 	}
 
 	/**
@@ -61,7 +61,7 @@ public class Evidence extends org.communitywitness.common.Evidence {
 	 */
 
 	public int writeToDb() throws SQLException {
-		Connection conn = new SQLConnection().databaseConnection();
+		Connection conn = SQLConnection.databaseConnection();
 
 		// if the evidence is brand new (has not been written to the db yet), it will have an id of -1
 		// once the evidence gets written, it is given an id by the db which will be pulled back into the object
@@ -112,6 +112,8 @@ public class Evidence extends org.communitywitness.common.Evidence {
 			queryStatement.executeUpdate();
 			queryStatement.close();
 		}
+		
+		conn.close();
 		return getId();
 	}
 }

--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/EvidenceResource.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/EvidenceResource.java
@@ -6,7 +6,6 @@ import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
-import java.io.IOException;
 import java.sql.SQLException;
 
 @Path("/evidence")
@@ -15,13 +14,14 @@ import java.sql.SQLException;
 public class EvidenceResource {
 	/**
 	 * Creates new evidence with the data contained in the sent object.
-	 * @param newEvidenceRequestData - an object containing the information about the evidence
+	 * @param newEvidenceRequestData an object containing the information about the evidence
+	 * @param user the authentication data of the requesting user
 	 * @return the actual id of the newly created evidence
 	 * @throws WebApplicationException if the report the evidence is associated with doesn't exist
 	 */
 	@RolesAllowed({UserRoles.WITNESS})
 	@POST
-	public int createEvidence(NewEvidenceRequest newEvidenceRequestData, @Context AuthenticatedUser user) throws WebApplicationException, SQLException, IOException {
+	public int createEvidence(NewEvidenceRequest newEvidenceRequestData, @Context AuthenticatedUser user) throws WebApplicationException {
 		// check if the report exists and belongs to the right witness
 		try {
 			Report relevantReport = new Report(newEvidenceRequestData.getReportId());
@@ -31,14 +31,20 @@ public class EvidenceResource {
 		} catch (SQLException exception) {
 			throw new WebApplicationException(Response.Status.NOT_FOUND);
 		}
-
-		Evidence newEvidence = new Evidence(newEvidenceRequestData);
-		return newEvidence.writeToDb();
+		
+		// try to write evidence to database
+		try {
+			Evidence newEvidence = new Evidence(newEvidenceRequestData);
+			return newEvidence.writeToDb();
+		} catch (SQLException exception) {
+			throw new WebApplicationException("Failed to write evidence to database.");
+		}
 	}
 	
 	/**
 	 * Returns the evidence with the given id.
-	 * @param evidenceId - the id of the evidence
+	 * @param evidenceId the id of the evidence
+	 * @param user the authentication data of the requesting user
 	 * @return the evidence data
 	 * @throws WebApplicationException if no evidence with the given id is found
 	 */

--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/Investigator.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/Investigator.java
@@ -16,7 +16,7 @@ public class Investigator extends org.communitywitness.common.Investigator {
 	 * Constructor that looks up an investigator in the database then fills that data into the object.
 	 * @param id - the id of the witness to lookup in the database.
 	 */
-	public Investigator(int id) throws SQLException, RuntimeException {
+	public Investigator(int id) throws SQLException {
 		// retrieve investigators account info
 		Connection conn = new SQLConnection().databaseConnection();
 		String query = "SELECT Name, Organization, OrganizationType, Rating " +
@@ -33,7 +33,7 @@ public class Investigator extends org.communitywitness.common.Investigator {
 			setOrganizationType(queryResults.getString(3));
 			setRating(queryResults.getDouble(4));
 		} else {
-			throw new RuntimeException("Investigator with the supplied ID does not exist in database");
+			throw new SQLException("Investigator with the supplied ID does not exist in database");
 		}
 		// retrieve ids of the reports the investigator is investigating
 		loadReports(conn);

--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/Investigator.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/Investigator.java
@@ -18,7 +18,7 @@ public class Investigator extends org.communitywitness.common.Investigator {
 	 */
 	public Investigator(int id) throws SQLException {
 		// retrieve investigators account info
-		Connection conn = new SQLConnection().databaseConnection();
+		Connection conn = SQLConnection.databaseConnection();
 		String query = "SELECT Name, Organization, OrganizationType, Rating " +
 				"FROM Investigator " +
 				"WHERE ID=?";
@@ -36,10 +36,9 @@ public class Investigator extends org.communitywitness.common.Investigator {
 			throw new SQLException("Investigator with the supplied ID does not exist in database");
 		}
 		// retrieve ids of the reports the investigator is investigating
-		loadReports(conn);
+		loadReports();
 
-		queryStatement.close();
-		conn.close();
+		SQLConnection.closeDbOperation(conn, queryStatement, queryResults);
 	}
 
 	/**
@@ -59,9 +58,10 @@ public class Investigator extends org.communitywitness.common.Investigator {
 	 * then saves that to this object.
 	 * @throws SQLException if no data is found
 	 */
-	public void loadReports(Connection conn) throws SQLException {
+	public void loadReports() throws SQLException {
 		ArrayList<Integer> reportIds = new ArrayList<>();
 
+		Connection conn = SQLConnection.databaseConnection();
 		String query = "SELECT ReportID FROM ReportInvestigations WHERE InvestigatorID=?";
 		PreparedStatement queryStatement = conn.prepareStatement(query);
 		queryStatement.setInt(1, getId());
@@ -70,7 +70,7 @@ public class Investigator extends org.communitywitness.common.Investigator {
 		while (queryResults.next()) {
 			reportIds.add(queryResults.getInt(1));
 		}
-		queryStatement.close();
+		SQLConnection.closeDbOperation(conn, queryStatement, queryResults);
 		setReports(reportIds);
 	}
 	
@@ -92,7 +92,7 @@ public class Investigator extends org.communitywitness.common.Investigator {
 	 * @throws SQLException if unable to write
 	 */
 	public int writeToDb() throws SQLException {
-		Connection conn = new SQLConnection().databaseConnection();
+		Connection conn = SQLConnection.databaseConnection();
 
 		// if the investigator is brand new (has not been written to the db yet), it will have an id of UNSET_ID (-1)
 		// once the investigator gets written, it is given an id by the db which will be pulled back into the object
@@ -141,6 +141,7 @@ public class Investigator extends org.communitywitness.common.Investigator {
 			queryStatement.close();
 		}
 
+		conn.close();
 		return getId();
 	}
 
@@ -149,7 +150,7 @@ public class Investigator extends org.communitywitness.common.Investigator {
 	 * @throws SQLException if unable to write (most likely due to foreign key constraint
 	 */
 	public void takeCase(int reportId) throws SQLException {
-		Connection conn = new SQLConnection().databaseConnection();
+		Connection conn = SQLConnection.databaseConnection();
 
 		String query = "INSERT INTO reportinvestigations (reportid, investigatorid) " +
 				"VALUES (?,?)";
@@ -159,6 +160,6 @@ public class Investigator extends org.communitywitness.common.Investigator {
 		queryStatement.setInt(2, getId());
 
 		queryStatement.executeUpdate();
-		queryStatement.close();
+		SQLConnection.closeDbOperation(conn, queryStatement, null);
 	}
 }

--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/InvestigatorResource.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/InvestigatorResource.java
@@ -21,9 +21,7 @@ import jakarta.ws.rs.core.Response;
 public class InvestigatorResource {
 	/**
 	 * Creates a new investigator with data sent by the client.
-	 * TODO: decide if this should be changed into a request somehow, 
-	 * 		perhaps with a separate requests table in the database to store them in.
-	 * @param newInvestigatorRequestData - object containing the new data to be inserted
+	 * @param newInvestigatorRequestData object containing the new data to be inserted
 	 * @return the id of the newly created investigator
 	 */
 	@PermitAll
@@ -51,7 +49,7 @@ public class InvestigatorResource {
 	
 	/**
 	 * Returns an investigators information from the database to the client
-	 * @param investigatorId - the id of the investigator to send data about
+	 * @param investigatorId the id of the investigator to send data about
 	 * @return the data about the investigator
 	 * @throws WebApplicationException if the investigator isn't found in the database
 	 */
@@ -73,8 +71,9 @@ public class InvestigatorResource {
 	/**
 	 * Updates the changeable parts of an investigators data with data sent by the client.
 	 * This takes a whole Investigator object so that making more forms changeable is simple.
-	 * @param investigatorId - the id of the investigator whose data should be updated
-	 * @param updateInvestigatorRequestData - an object containing the updated data
+	 * @param investigatorId the id of the investigator whose data should be updated
+	 * @param updateInvestigatorRequestData an object containing the updated data
+	 * @param user the authentication data of the requesting user
 	 * @return An OK status on success, otherwise a NOT_FOUND status when no matching investigator is found.
 	 */
 	@RolesAllowed({UserRoles.INVESTIGATOR})
@@ -102,7 +101,7 @@ public class InvestigatorResource {
 	
 	/**
 	 * Returns the information about the currently logged in investigator.
-	 * @param user the authentication details of the current user
+	 * @param user the authentication details of the requesting user
 	 * @return the data about the investigator that's logged in
 	 * @throws WebApplicationException if the data could not be retrieved
 	 */
@@ -124,14 +123,15 @@ public class InvestigatorResource {
 	/**
 	 * Connects this investigator to a report (case)
 	 * Takes an investigator id and a case id
-	 * @param investigatorId - the id of the investigator
-	 * @param reportId - the id of the report they're interested in
+	 * @param investigatorId the id of the investigator
+	 * @param reportId the id of the report they're interested in
+	 * @param user the authentication data of the requesting user
 	 * @return An OK status on success, otherwise a NOT_FOUND status when no matching investigator/report is found.
 	 */
 	@RolesAllowed({UserRoles.INVESTIGATOR})
 	@POST
 	@Path("/{investigatorId}/take/{reportId}")
-	public Response takeCase(@PathParam("investigatorId") int investigatorId, @PathParam("reportId") int reportId, @Context AuthenticatedUser user) throws SQLException {
+	public Response takeCase(@PathParam("investigatorId") int investigatorId, @PathParam("reportId") int reportId, @Context AuthenticatedUser user) {
 		Investigator investigator;
 		
 		if (user.getId() != investigatorId)
@@ -139,11 +139,6 @@ public class InvestigatorResource {
 
 		try {
 			investigator = new Investigator(investigatorId);
-		} catch (RuntimeException exception) {
-			return Response.status(Response.Status.NOT_FOUND).build();
-		}
-
-		try {
 			investigator.takeCase(reportId);
 		} catch (SQLException exception) {
 			return Response.status(Response.Status.NOT_FOUND).build();

--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/Report.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/Report.java
@@ -19,7 +19,7 @@ public class Report extends org.communitywitness.common.Report {
      */
     public Report(int id) throws SQLException {
         // retrieve the primary info about the report
-        Connection conn = new SQLConnection().databaseConnection();
+        Connection conn = SQLConnection.databaseConnection();
         String query = "SELECT resolved, description, time, location, witnessID " +
                 "FROM report " +
                 "WHERE id=?";
@@ -35,6 +35,7 @@ public class Report extends org.communitywitness.common.Report {
             setLocation(queryResults.getString(4));
             setWitnessId(queryResults.getInt(5));
         } else {
+        	SQLConnection.closeDbOperation(conn, queryStatement, queryResults);
             throw new RuntimeException("Report with the supplied ID does not exist in database");
         }
 
@@ -43,8 +44,7 @@ public class Report extends org.communitywitness.common.Report {
         loadEvidence(conn);
 
         // close out sql stuff
-        queryStatement.close();
-        conn.close();
+        SQLConnection.closeDbOperation(conn, queryStatement, queryResults);
     }
 
     /**
@@ -109,7 +109,7 @@ public class Report extends org.communitywitness.common.Report {
      * @throws SQLException if unable to write
      */
     public int writeToDb() throws SQLException {
-        Connection conn = new SQLConnection().databaseConnection();
+        Connection conn = SQLConnection.databaseConnection();
 
         // if the report is brand new (has not been written to the db yet), it will have an id of UNSET_ID (-1)
         // once the report gets written, it is given an id by the db which will be pulled back into the object

--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/ReportComment.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/ReportComment.java
@@ -16,7 +16,7 @@ public class ReportComment extends org.communitywitness.common.ReportComment {
 	 * @param id - the id of the witness to lookup in the database.
 	 */
 	public ReportComment(int id) throws SQLException {
-		Connection conn = new SQLConnection().databaseConnection();
+		Connection conn = SQLConnection.databaseConnection();
 		String query = "SELECT ID, ReportID, InvestigatorID, Contents " +
 				"FROM ReportComments " +
 				"WHERE ID=?";
@@ -34,8 +34,7 @@ public class ReportComment extends org.communitywitness.common.ReportComment {
 			throw new RuntimeException("Comment with the supplied ID does not exist in database");
 		}
 
-		queryResults.close();
-		queryStatement.close();
+		SQLConnection.closeDbOperation(conn, queryStatement, queryResults);
 	}
 
 	/**
@@ -56,7 +55,7 @@ public class ReportComment extends org.communitywitness.common.ReportComment {
 	 * @throws SQLException if unable to write
 	 */
 	public int writeToDb() throws SQLException {
-		Connection conn = new SQLConnection().databaseConnection();
+		Connection conn = SQLConnection.databaseConnection();
 
 		// if the evidence is brand new (has not been written to the db yet), it will have an id of -1
 		// once the evidence gets written, it is given an id by the db which will be pulled back into the object
@@ -100,6 +99,8 @@ public class ReportComment extends org.communitywitness.common.ReportComment {
 			queryStatement.executeUpdate();
 			queryStatement.close();
 		}
+		
+		conn.close();
 		return getId();
 	}
 }

--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/ReportCommentResource.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/ReportCommentResource.java
@@ -20,7 +20,7 @@ public class ReportCommentResource {
 	 */
 	@RolesAllowed({UserRoles.INVESTIGATOR})
 	@POST
-	public int createReportComment(ReportCommentRequest reportCommentRequest, @Context AuthenticatedUser user) throws WebApplicationException, SQLException {
+	public int createReportComment(ReportCommentRequest reportCommentRequest, @Context AuthenticatedUser user) throws WebApplicationException {
 		if (user.getId() != reportCommentRequest.getInvestigatorId())
 			AuthorizationFilter.unauthorizedAccessResponse("Investigators may only file report comments as themselves.");
 		
@@ -31,9 +31,17 @@ public class ReportCommentResource {
 		} catch (SQLException exception) {
 			throw new WebApplicationException(Response.Status.NOT_FOUND);
 		}
-
-		ReportComment newComment = new ReportComment(reportCommentRequest);
-		return newComment.writeToDb();
+		
+		// try to write comment to database
+		int newCommentId;
+		try {
+			ReportComment newComment = new ReportComment(reportCommentRequest);
+			newCommentId = newComment.writeToDb();
+		} catch (SQLException exception) {
+			throw new WebApplicationException("Failed to write comment to database.");
+		}
+		
+		return newCommentId;
 	}
 	
 	/**

--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/ReportResource.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/ReportResource.java
@@ -25,7 +25,7 @@ public class ReportResource {
 	public List<Report> queryReports() throws WebApplicationException {
 
 		try {
-			Connection conn = new SQLConnection().databaseConnection();
+			Connection conn = SQLConnection.databaseConnection();
 			String query = "SELECT id, resolved, description, time, location, witnessID FROM report";
 			ResultSet queryResults = conn.prepareStatement(query).executeQuery();
 
@@ -45,8 +45,7 @@ public class ReportResource {
 			}
 
 			// close out sql stuff
-			queryResults.close();
-			conn.close();
+			SQLConnection.closeDbOperation(conn, null, queryResults);
 
 			return results;
 		} catch (SQLException exception) {

--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/SQLConnection.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/SQLConnection.java
@@ -11,16 +11,12 @@ public class SQLConnection {
 	private static HikariDataSource connectionPool = new HikariDataSource();
 
 	/**
-	 * Setups the database connection pool.
-	 * @return true on success, false on failure
+	 * Sets up the database connection pool.
 	 */
-	public static boolean connectToDatabase() {
+	public static void connectToDatabase() {
 		connectionPool.setJdbcUrl(Settings.getInstance().getDatabaseUrl());
 		connectionPool.setUsername(Settings.getInstance().getDatabaseUsername());
 		connectionPool.setPassword(Settings.getInstance().getDatabasePassword());
-
-		return connectionPool.isRunning();
-
 	}
 
 	/**

--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/SQLConnection.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/SQLConnection.java
@@ -1,13 +1,51 @@
 package org.communitywitness.api;
 
 import java.sql.Connection;
-import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 
+import com.zaxxer.hikari.HikariDataSource;
+
 public class SQLConnection {
-    protected Connection databaseConnection() throws SQLException {
-        return DriverManager.getConnection(Settings.getInstance().getDatabaseUrl(),
-        		Settings.getInstance().getDatabaseUsername(), 
-        		Settings.getInstance().getDatabasePassword());
-    }
+	private static HikariDataSource connectionPool = new HikariDataSource();
+
+	/**
+	 * Setups the database connection pool.
+	 * @return true on success, false on failure
+	 */
+	public static boolean connectToDatabase() {
+		connectionPool.setJdbcUrl(Settings.getInstance().getDatabaseUrl());
+		connectionPool.setUsername(Settings.getInstance().getDatabaseUsername());
+		connectionPool.setPassword(Settings.getInstance().getDatabasePassword());
+
+		return connectionPool.isRunning();
+
+	}
+
+	/**
+	 * Returns a connection to the database.
+	 * @return a connection to the database
+	 * @throws SQLException on database error
+	 */
+	public static Connection databaseConnection() throws SQLException {
+		return connectionPool.getConnection();
+	}
+
+	/**
+	 * A helper function that closes all the parts of a database operation in the correct order.
+	 * @param dbConnection the connection to the database or null
+	 * @param statement the statement ran against the database or null
+	 * @param results the results returned by the database or null for update statements
+	 * @throws SQLException if an error occurs while closing these
+	 */
+	public static void closeDbOperation(Connection dbConnection, PreparedStatement statement, 
+			ResultSet results) throws SQLException {
+		if (results != null)
+			results.close();
+		if (statement != null)
+			statement.close();
+		if (dbConnection != null)
+			dbConnection.close();
+	}
 }

--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/Server.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/Server.java
@@ -77,8 +77,7 @@ public class Server {
 		if (args.length > 0)
 			Settings.loadSettings(args[0]);
 		
-		if (!SQLConnection.connectToDatabase())
-			System.err.println("Error: failed to connect to database.");
+		SQLConnection.connectToDatabase();
 		
 		if (!startServer())
 			System.exit(-1);

--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/Server.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/Server.java
@@ -75,7 +75,10 @@ public class Server {
 	public static void main(String[] args) {
 		// Load users settings if they specified a settings file
 		if (args.length > 0)
-			Settings.loadSettings(args[0]);	
+			Settings.loadSettings(args[0]);
+		
+		if (!SQLConnection.connectToDatabase())
+			System.err.println("Error: failed to connect to database.");
 		
 		if (!startServer())
 			System.exit(-1);

--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/Witness.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/Witness.java
@@ -18,7 +18,7 @@ public class Witness extends org.communitywitness.common.Witness {
      */
     public Witness(int id) throws SQLException {
         // retrieve witnesses account info
-        Connection conn = new SQLConnection().databaseConnection();
+        Connection conn = SQLConnection.databaseConnection();
         String query = "SELECT Name, Rating, Location " +
                 "FROM Witness " +
                 "WHERE ID=?";
@@ -32,15 +32,13 @@ public class Witness extends org.communitywitness.common.Witness {
             setRating(queryResults.getDouble(2));
             setLocation(queryResults.getString(3));
         } else {
+        	SQLConnection.closeDbOperation(conn, queryStatement, queryResults);
             throw new RuntimeException("Witness with the supplied ID does not exist in database");
         }
         // retrieve ids of the witnesses filed cases
         loadReports(conn);
 
-        queryResults.close();
-        conn.close();
-        
-
+        SQLConnection.closeDbOperation(conn, queryStatement, queryResults);
     }
 
     /**
@@ -101,7 +99,7 @@ public class Witness extends org.communitywitness.common.Witness {
      * @throws SQLException if unable to write
      */
     public int writeToDb() throws SQLException {
-        Connection conn = new SQLConnection().databaseConnection();
+        Connection conn = SQLConnection.databaseConnection();
 
         // if the report is brand new (has not been written to the db yet), it will have an id of UNSET_ID (-1)
         // once the report gets written, it is given an id by the db which will be pulled back into the object
@@ -147,6 +145,7 @@ public class Witness extends org.communitywitness.common.Witness {
             queryStatement.close();
         }
 
+        conn.close();
         return getId();
     }
 }

--- a/org-communitywitness-api/src/main/java/org/communitywitness/api/WitnessResource.java
+++ b/org-communitywitness-api/src/main/java/org/communitywitness/api/WitnessResource.java
@@ -44,9 +44,10 @@ public class WitnessResource {
 
 	/**
 	 * Returns a witness from the database to the client
-	 * @param witnessId - the id of the witness to send
+	 * @param witnessId the id of the witness to send
+	 * @param user the authentication data of the requesting user
 	 * @return the witness with the given id
-	 * @throws WebApplicationException if the witness isn't in the database
+	 * @throws WebApplicationException if the witness isn't in the database or on authorization failure
 	 */
 	@RolesAllowed({UserRoles.WITNESS})
 	@GET
@@ -69,8 +70,9 @@ public class WitnessResource {
 	/**
 	 * Updates the changeable parts of a witness' data with data sent by the client.
 	 * This takes a whole witness object so that making more forms changeable is possible with minimal modifications.
-	 * @param witnessId - the id of the witness whose data should be updated
-	 * @param witnessRequestData - the updated data for the witness
+	 * @param witnessId the id of the witness whose data should be updated
+	 * @param witnessRequestData the updated data for the witness
+	 * @param user the authentication data of the requesting user
 	 * @return A status of OK if the witness is found and update, otherwise a status of NOT_FOUND
 	 */
 	@RolesAllowed({UserRoles.WITNESS})
@@ -93,7 +95,7 @@ public class WitnessResource {
 	
 	/**
 	 * Returns the information about the currently logged in witness.
-	 * @param user the authentication details of the current user
+	 * @param user the authentication details of the requesting user
 	 * @return the data about the witness that's logged in
 	 * @throws WebApplicationException if the data could not be retrieved
 	 */


### PR DESCRIPTION
This uses a library that manages a pool of database connections instead of making new ones each time, and my stress tests indicated that this improved performance significantly with the old code peaking at ~8000ms avg for 500 users and this one peaking at ~100ms avg for 500 users. I also ended up setting up the API authorization stuff for the stress test suite to do this, so that's in here too.